### PR TITLE
Implement `From<RawCoord>` for `f32/64`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ license = "MIT"
 
 
 [dev-dependencies]
+approx = "^0.3.0"
 memmap = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,7 @@
 //! It is intended to be used as an unopinionated base for building higher level data structures
 //! representing traces/tasks/etc..
 
+#[cfg(test)] #[macro_use] extern crate approx;
+
 pub mod util;
 pub mod records;

--- a/src/util/coord.rs
+++ b/src/util/coord.rs
@@ -57,6 +57,26 @@ impl RawCoord {
     }
 }
 
+impl From<RawCoord> for f32 {
+    fn from(coord: RawCoord) -> Self {
+        let value = coord.degrees as Self + coord.minute_thousandths as Self / 60_000.;
+        match coord.sign {
+            Compass::North | Compass::East => value,
+            Compass::South | Compass::West => -value,
+        }
+    }
+}
+
+impl From<RawCoord> for f64 {
+    fn from(coord: RawCoord) -> Self {
+        let value = coord.degrees as Self + coord.minute_thousandths as Self / 60_000.;
+        match coord.sign {
+            Compass::North | Compass::East => value,
+            Compass::South | Compass::West => -value,
+        }
+    }
+}
+
 /// A raw lat/lon pair.
 #[derive(Debug, PartialEq, Eq)]
 pub struct RawPosition {
@@ -93,5 +113,11 @@ mod test {
                    RawCoord { degrees: 51, minute_thousandths: 52265, sign: Compass::East });
         assert_eq!(RawCoord::parse_lon("05152265W").unwrap(),
                    RawCoord { degrees: 51, minute_thousandths: 52265, sign: Compass::West });
+    }
+
+    #[test]
+    fn convert_to_float() {
+        assert_relative_eq!(RawCoord::parse_lon("05152265E").unwrap().into(), 51.871082f32);
+        assert_relative_eq!(RawCoord::parse_lat("5152265S").unwrap().into(), -51.87108333333333f64);
     }
 }


### PR DESCRIPTION
This makes it easier to convert a `RawCoord` to a float that can be used for calculations.

I'm using https://docs.rs/approx/ for the test assertions, as `assert_eq!()` does not work for floats.