### PR TITLE
Replace unsafe `memmap` usage with `BufReader`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,4 @@ repository = "https://github.com/Joey9801/igc-rs"
 documentation = "https://docs.rs/igc"
 license = "MIT"
 
-
 [dev-dependencies]
-memmap = "0.7.0"

--- a/examples/read_fixes.rs
+++ b/examples/read_fixes.rs
@@ -1,18 +1,23 @@
 extern crate igc;
-extern crate memmap;
 
 use std::fs::File;
-use memmap::MmapOptions;
+use std::io::BufReader;
+use std::io::BufRead;
 use igc::records::Record;
 
 fn main() {
     let filename = "examples/example.igc";
 
     let file = File::open(filename).unwrap();
-    let mmap = unsafe { MmapOptions::new().map(&file) }.unwrap();
+    let reader = BufReader::new(&file);
 
-    for line in std::str::from_utf8(&mmap).unwrap().lines() {
-        let record = match Record::parse_line(line) {
+    for result in reader.lines() {
+        let line = match result {
+            Ok(line) => line,
+            Err(_) => std::process::exit(-1),
+        };
+
+        let record = match Record::parse_line(&line) {
             Ok(record) => record,
             Err(_) => std::process::exit(-1),
         };


### PR DESCRIPTION
This essentially does the same thing, but without an additional dependency and without using `unsafe`.