### PR TITLE
Implement `FromStr` for `RawPosition`

### DIFF
--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -42,7 +42,7 @@ impl<'a> BRecord<'a> {
         }
 
         let timestamp = Time::parse(&line[1..7])?;
-        let pos = RawPosition::parse_lat_lon(&line[7..24])?;
+        let pos = line[7..24].parse()?;
 
         let fix_valid = match &line[24..25] {
             "A" => FixValid::Valid,

--- a/src/records/c_record.rs
+++ b/src/records/c_record.rs
@@ -74,7 +74,7 @@ impl<'a> CRecordTurnpoint<'a> {
         assert!(line.len() >= 18);
         assert!(line.as_bytes()[0] == b'C');
 
-        let position = RawPosition::parse_lat_lon(&line[1..18])?;
+        let position = line[1..18].parse()?;
         let turnpoint_name = if line.len() > 18 {
             Some(&line[18..])
         } else {

--- a/src/util/coord.rs
+++ b/src/util/coord.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use super::parse_error::*;
 
 /// Enumeration of cardinal directions
@@ -74,10 +75,17 @@ impl RawPosition {
     }
 }
 
+impl FromStr for RawPosition {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, ParseError> {
+        Self::parse_lat_lon(s)
+    }
+}
 
 #[cfg(test)]
 mod test {
-    use super::{RawCoord,Compass};
+    use super::*;
 
     #[test]
     fn raw_coord_parse_lat() {
@@ -93,5 +101,13 @@ mod test {
                    RawCoord { degrees: 51, minute_thousandths: 52265, sign: Compass::East });
         assert_eq!(RawCoord::parse_lon("05152265W").unwrap(),
                    RawCoord { degrees: 51, minute_thousandths: 52265, sign: Compass::West });
+    }
+
+    #[test]
+    fn parse_raw_position() {
+        assert_eq!("5152265N05152265W".parse::<RawPosition>().unwrap(), RawPosition {
+            lat: RawCoord { degrees: 51, minute_thousandths: 52265, sign: Compass::North },
+            lon: RawCoord { degrees: 51, minute_thousandths: 52265, sign: Compass::West },
+        });
     }
 }


### PR DESCRIPTION
This will allow us to simplify `RawPosition::parse_lat_lon("5152265N05152265W")` to `"5152265N05152265W".parse()` in most cases