### PR TITLE
Use Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Joe Roberts <joe@jwjr.co.uk>"]
 repository = "https://github.com/Joey9801/igc-rs"
 documentation = "https://docs.rs/igc"
 license = "MIT"
-
+edition = "2018"
 
 [dev-dependencies]
 memmap = "0.7.0"

--- a/examples/read_fixes.rs
+++ b/examples/read_fixes.rs
@@ -1,6 +1,3 @@
-extern crate igc;
-extern crate memmap;
-
 use std::fs::File;
 use memmap::MmapOptions;
 use igc::records::Record;

--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -99,7 +99,6 @@ impl<'a> ARecord<'a> {
     /// Parse an IGC A Record string
     ///
     /// ```
-    /// # extern crate igc;
     /// # use igc::records::{ ARecord, Manufacturer };
     /// let record = ARecord::parse("ACAMWatFoo").unwrap();
     /// assert_eq!(record.manufacturer, Manufacturer::CambridgeAeroInstruments);

--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -31,7 +31,6 @@ impl<'a> BRecord<'a> {
     /// Parse an IGC B record string.
     ///
     /// ```
-    /// # extern crate igc;
     /// # use igc::{ records::BRecord, util::Time };
     /// let record = BRecord::parse("B0941145152265N00032642WA0011500115").unwrap();
     /// assert_eq!(record.timestamp, Time::from_hms(9, 41, 14));

--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -1,5 +1,5 @@
 use crate::util::{Time,RawPosition,ParseError};
-use records::extension::Extendable;
+use crate::records::extension::Extendable;
 
 
 /// Possible values for the "fix valid" field of a B Record
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
 
     use crate::util::{Time,Compass,RawCoord,RawPosition};
-    use records::extension::Extension;
+    use crate::records::extension::Extension;
 
     #[test]
     fn simple_brecord_parse() {

--- a/src/records/c_record.rs
+++ b/src/records/c_record.rs
@@ -19,7 +19,6 @@ impl<'a> CRecordDeclaration<'a> {
     /// Parse a string as a C record task declaration
     ///
     /// ```
-    /// # extern crate igc;
     /// # use igc::{ records::CRecordDeclaration, util::{Time,Date} };
     /// let record = CRecordDeclaration::parse("C230718092044000000000204Foo task").unwrap();
     /// assert_eq!(record.date, Date::from_dmy(23, 7, 18));
@@ -61,7 +60,6 @@ impl<'a> CRecordTurnpoint<'a> {
     /// Parse a string as a C record task turnpoint
     ///
     /// ```
-    /// # extern crate igc;
     /// # use igc::{ records::CRecordTurnpoint, util::{Compass,RawCoord} };
     /// let record = CRecordTurnpoint::parse("C5156040N00038120WLBZ-Leighton Buzzard NE").unwrap();
     /// assert_eq!(record.position.lat,

--- a/src/records/k_record.rs
+++ b/src/records/k_record.rs
@@ -1,5 +1,5 @@
 use crate::util::{Time,ParseError};
-use records::extension::Extendable;
+use crate::records::extension::Extendable;
 
 /// An extension data record.
 ///
@@ -36,7 +36,7 @@ impl<'a> Extendable for KRecord<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use records::extension::Extension;
+    use crate::records::extension::Extension;
 
     #[test]
     fn krecord_parse() {

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -66,7 +66,6 @@ impl<'a> Record<'a> {
     /// Perform a minimal parsing of a single IGC file line.
     ///
     /// ```
-    /// # extern crate igc;
     /// use igc::records::{Record,DataSource};
     /// match Record::parse_line("HFFTYFRTYPE:LXNAV,LX8000F") {
     ///     Ok(Record::H(header_rec)) => {


### PR DESCRIPTION
This will let us get rid of the unnecessary `extern crate` declarations and will enable us to use a few other features in the future.