### PR TITLE
Fix invalid character boundary crashes and add basic `proptest` checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dev-dependencies]
 approx = "^0.3.0"
 criterion = "0.2"
+proptest = "0.8.7"
 
 [[bench]]
 name = "benchmark"

--- a/proptest-regressions/records/a_record.txt
+++ b/proptest-regressions/records/a_record.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 3244273881 1542399201 2325479061 4046880040 # shrinks to s = "A0ꢀ￼"

--- a/proptest-regressions/records/b_record.txt
+++ b/proptest-regressions/records/b_record.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 2094794938 3925104165 1979193435 1607451583 # shrinks to s = "B🌀®0  A¡𞤀𐘀 𐀀a0⮘ ে"
+xs 1718405692 2295129719 523063086 2037652598 # shrinks to s = "BA𑩐 𫠠A🀰\u{1107f}0®A0🡠aaAஜ"

--- a/proptest-regressions/records/c_record.txt
+++ b/proptest-regressions/records/c_record.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 2437192779 1576099512 1903745588 3885128842 # shrinks to s = "C𑴀𑠀𖭽 ₐ𞸧\u{1daa1}"
+xs 673828249 2790637114 930544289 392057644 # shrinks to s = "C"
+xs 2995289326 2850772533 3171143290 3790891302 # shrinks to s = "Cୋ0טּA𐣠0Aaਲ🤀®"
+xs 765816543 1845765364 1775432819 980553443 # shrinks to s = "C aᜀ𐍐Aמּ a𑢠 0𑘀"

--- a/proptest-regressions/records/h_record.txt
+++ b/proptest-regressions/records/h_record.txt
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 1759464786 1751145372 3637599596 4235268146 # shrinks to s = "H"
+xs 149770529 1738105424 2296778510 3901081933 # shrinks to s = "H0:0 "
+xs 2245175836 4083561202 3942119179 1562916076 # shrinks to s = "H:00 a "
+xs 1119984696 4133735085 2723203127 940298834 # shrinks to s = "HAaA :a"
+xs 2574027845 1488020979 3480431610 2215872591 # shrinks to s = "Hࢠa𞺀"

--- a/proptest-regressions/records/k_record.txt
+++ b/proptest-regressions/records/k_record.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 582978124 1268721127 1187853473 3479354889 # shrinks to s = "K000அ𞻰"

--- a/proptest-regressions/records/mod.txt
+++ b/proptest-regressions/records/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+xs 701375950 2163573791 1757240426 1914575457 # shrinks to s = ""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,9 @@
 //! It is intended to be used as an unopinionated base for building higher level data structures
 //! representing traces/tasks/etc..
 
+#[cfg(test)]
+#[macro_use]
+extern crate proptest;
+
 pub mod records;
 pub mod util;

--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -172,7 +172,7 @@ impl<'a> ARecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.bytes().take(7).all(|b| b.is_ascii()) {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let manufacturer = Manufacturer::parse_triple_char(&line[1..4]);

--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -171,6 +171,9 @@ impl<'a> ARecord<'a> {
         if line.len() < 7 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(4) || !line.is_char_boundary(7) {
+            return Err(ParseError::SyntaxError);
+        }
 
         let manufacturer = Manufacturer::parse_triple_char(&line[1..4]);
         let unique_id = &line[4..7];
@@ -218,6 +221,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(ARecord::parse("A0ꢀ￼").is_err());
+    }
+
+    #[test]
     fn arecord_fmt() {
         assert_eq!(
             format!(
@@ -230,5 +238,13 @@ mod tests {
             ),
             "ACAMWatFoo"
         );
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "A\\PC*") {
+            ARecord::parse(&s);
+        }
     }
 }

--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -171,7 +171,7 @@ impl<'a> ARecord<'a> {
         if line.len() < 7 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(4) || !line.is_char_boundary(7) {
+        if !line.bytes().take(7).all(|b| b.is_ascii()) {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -40,6 +40,14 @@ impl<'a> BRecord<'a> {
         if line.len() < Self::BASE_LENGTH {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(7)
+            || !line.is_char_boundary(24)
+            || !line.is_char_boundary(25)
+            || !line.is_char_boundary(30)
+            || !line.is_char_boundary(35)
+        {
+            return Err(ParseError::SyntaxError);
+        }
 
         let timestamp = line[1..7].parse()?;
         let pos = line[7..24].parse()?;
@@ -129,6 +137,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(BRecord::parse("B🌀®0  A¡𞤀𐘀 𐀀a0⮘ ে").is_err());
+        assert!(BRecord::parse("BA𑩐 𫠠A🀰\u{1107f}0®A0🡠aaAஜ").is_err());
+    }
+
+    #[test]
     fn simple_brecord_format() {
         let expected = "B0941145152265N00032642WA00115-0116FooExtensionString";
         let record = BRecord {
@@ -169,5 +183,13 @@ mod tests {
         let extracted = record.get_extension(&extension).unwrap();
         let expected = "01234";
         assert_eq!(extracted, expected);
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "B\\PC*") {
+            BRecord::parse(&s);
+        }
     }
 }

--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -41,7 +41,7 @@ impl<'a> BRecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let timestamp = line[1..7].parse()?;

--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -40,12 +40,7 @@ impl<'a> BRecord<'a> {
         if line.len() < Self::BASE_LENGTH {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(7)
-            || !line.is_char_boundary(24)
-            || !line.is_char_boundary(25)
-            || !line.is_char_boundary(30)
-            || !line.is_char_boundary(35)
-        {
+        if !line.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/c_record.rs
+++ b/src/records/c_record.rs
@@ -34,7 +34,7 @@ impl<'a> CRecordDeclaration<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.bytes().take(25).all(|b| b.is_ascii()) {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         assert!(line.as_bytes()[0] == b'C');
@@ -98,7 +98,7 @@ impl<'a> CRecordTurnpoint<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.bytes().take(18).all(|b| b.is_ascii()) {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         assert!(line.as_bytes()[0] == b'C');

--- a/src/records/c_record.rs
+++ b/src/records/c_record.rs
@@ -33,6 +33,14 @@ impl<'a> CRecordDeclaration<'a> {
         if line.len() < 25 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(7)
+            || !line.is_char_boundary(13)
+            || !line.is_char_boundary(19)
+            || !line.is_char_boundary(23)
+            || !line.is_char_boundary(25)
+        {
+            return Err(ParseError::SyntaxError);
+        }
 
         assert!(line.as_bytes()[0] == b'C');
 
@@ -92,6 +100,9 @@ impl<'a> CRecordTurnpoint<'a> {
     /// ```
     pub fn parse(line: &'a str) -> Result<Self, ParseError> {
         if line.len() < 18 {
+            return Err(ParseError::SyntaxError);
+        }
+        if !line.is_char_boundary(18) {
             return Err(ParseError::SyntaxError);
         }
 
@@ -165,6 +176,11 @@ mod tests {
     }
 
     #[test]
+    fn c_record_declaration_parse_with_invalid_char_boundary() {
+        assert!(CRecordDeclaration::parse("C𑠀𖭽ₐ𞸧\u{1daa1}").is_err());
+    }
+
+    #[test]
     fn c_record_declaration_format() {
         let expected_string = "C230718092044000000000204Foo task";
         let mut declaration = CRecordDeclaration {
@@ -212,5 +228,24 @@ mod tests {
     #[test]
     fn c_record_turnpoint_parse_with_missing_content() {
         assert!(CRecordTurnpoint::parse("C").is_err());
+    }
+
+    #[test]
+    fn c_record_turnpoint_parse_with_invalid_char_boundary() {
+        assert!(CRecordTurnpoint::parse("C𑠀𖭽ₐ𞸧\u{1daa1}").is_err());
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_declaration_doesnt_crash(s in "C\\PC*") {
+            CRecordDeclaration::parse(&s);
+        }
+
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_turnpoint_doesnt_crash(s in "C\\PC*") {
+            CRecordTurnpoint::parse(&s);
+        }
     }
 }

--- a/src/records/c_record.rs
+++ b/src/records/c_record.rs
@@ -33,12 +33,7 @@ impl<'a> CRecordDeclaration<'a> {
         if line.len() < 25 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(7)
-            || !line.is_char_boundary(13)
-            || !line.is_char_boundary(19)
-            || !line.is_char_boundary(23)
-            || !line.is_char_boundary(25)
-        {
+        if !line.bytes().take(25).all(|b| b.is_ascii()) {
             return Err(ParseError::SyntaxError);
         }
 
@@ -102,7 +97,7 @@ impl<'a> CRecordTurnpoint<'a> {
         if line.len() < 18 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(18) {
+        if !line.bytes().take(18).all(|b| b.is_ascii()) {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/c_record.rs
+++ b/src/records/c_record.rs
@@ -91,7 +91,10 @@ impl<'a> CRecordTurnpoint<'a> {
     /// assert_eq!(record.turnpoint_name, Some("LBZ-Leighton Buzzard NE"));
     /// ```
     pub fn parse(line: &'a str) -> Result<Self, ParseError> {
-        assert!(line.len() >= 18);
+        if line.len() < 18 {
+            return Err(ParseError::SyntaxError);
+        }
+
         assert!(line.as_bytes()[0] == b'C');
 
         let position = line[1..18].parse()?;
@@ -157,6 +160,11 @@ mod tests {
     }
 
     #[test]
+    fn c_record_declaration_parse_with_missing_content() {
+        assert!(CRecordDeclaration::parse("C").is_err());
+    }
+
+    #[test]
     fn c_record_declaration_format() {
         let expected_string = "C230718092044000000000204Foo task";
         let mut declaration = CRecordDeclaration {
@@ -199,5 +207,10 @@ mod tests {
         };
 
         assert_eq!(parsed_turnpoint, expected);
+    }
+
+    #[test]
+    fn c_record_turnpoint_parse_with_missing_content() {
+        assert!(CRecordTurnpoint::parse("C").is_err());
     }
 }

--- a/src/records/d_record.rs
+++ b/src/records/d_record.rs
@@ -76,4 +76,12 @@ mod tests {
 
         assert_eq!(format!("{}", record), expected_string);
     }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "D\\PC*") {
+            DRecord::parse(&s);
+        }
+    }
 }

--- a/src/records/e_record.rs
+++ b/src/records/e_record.rs
@@ -19,7 +19,7 @@ impl<'a> ERecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.bytes().take(10).all(|b| b.is_ascii()) {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         assert_eq!(line.as_bytes()[0], b'E');

--- a/src/records/e_record.rs
+++ b/src/records/e_record.rs
@@ -18,7 +18,7 @@ impl<'a> ERecord<'a> {
         if line.len() < 10 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(7) || !line.is_char_boundary(10) {
+        if !line.bytes().take(10).all(|b| b.is_ascii()) {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/e_record.rs
+++ b/src/records/e_record.rs
@@ -18,6 +18,9 @@ impl<'a> ERecord<'a> {
         if line.len() < 10 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(7) || !line.is_char_boundary(10) {
+            return Err(ParseError::SyntaxError);
+        }
 
         assert_eq!(line.as_bytes()[0], b'E');
 
@@ -68,6 +71,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(ERecord::parse("Eⶠ𑛀  ").is_err());
+    }
+
+    #[test]
     fn erecord_format() {
         let expected_string = "E120515FOOText";
         let record = ERecord {
@@ -77,5 +85,13 @@ mod tests {
         };
 
         assert_eq!(format!("{}", record), expected_string);
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "E\\PC*") {
+            ERecord::parse(&s);
+        }
     }
 }

--- a/src/records/extension.rs
+++ b/src/records/extension.rs
@@ -113,7 +113,7 @@ impl<'a> ExtensionDefRecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let num_extensions = line[1..3].parse::<u8>()?;

--- a/src/records/extension.rs
+++ b/src/records/extension.rs
@@ -112,6 +112,9 @@ impl<'a> ExtensionDefRecord<'a> {
         if line.len() < 3 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.as_bytes().iter().all(u8::is_ascii) {
+            return Err(ParseError::SyntaxError);
+        }
 
         let num_extensions = line[1..3].parse::<u8>()?;
 
@@ -171,5 +174,18 @@ mod tests {
         };
 
         assert_eq!(parsed_record, expected);
+    }
+
+    #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(ExtensionDefRecord::parse("I\u{1107f}").is_err());
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "I\\PC*") {
+            ExtensionDefRecord::parse(&s);
+        }
     }
 }

--- a/src/records/extension.rs
+++ b/src/records/extension.rs
@@ -112,7 +112,7 @@ impl<'a> ExtensionDefRecord<'a> {
         if line.len() < 3 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.as_bytes().iter().all(u8::is_ascii) {
+        if !line.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/f_record.rs
+++ b/src/records/f_record.rs
@@ -15,7 +15,7 @@ impl<'a> FRecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let time = line[1..7].parse()?;

--- a/src/records/f_record.rs
+++ b/src/records/f_record.rs
@@ -14,6 +14,9 @@ impl<'a> FRecord<'a> {
         if line.len() < 7 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(7) {
+            return Err(ParseError::SyntaxError);
+        }
 
         let time = line[1..7].parse()?;
 
@@ -88,6 +91,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(FRecord::parse("Fኲበ᧞").is_err());
+    }
+
+    #[test]
     fn satellite_iter() {
         let satellite_array = SatelliteArray::new("AABBCCDDEE");
         assert_eq!(
@@ -105,5 +113,13 @@ mod tests {
         };
 
         assert_eq!(format!("{}", record), expected_string);
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "F\\PC*") {
+            FRecord::parse(&s);
+        }
     }
 }

--- a/src/records/f_record.rs
+++ b/src/records/f_record.rs
@@ -14,7 +14,7 @@ impl<'a> FRecord<'a> {
         if line.len() < 7 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(7) {
+        if !line.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/g_record.rs
+++ b/src/records/g_record.rs
@@ -23,3 +23,16 @@ impl<'a> fmt::Display for GRecord<'a> {
         write!(f, "G{}", self.data)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "G\\PC*") {
+            GRecord::parse(&s);
+        }
+    }
+}

--- a/src/records/h_record.rs
+++ b/src/records/h_record.rs
@@ -49,7 +49,7 @@ impl<'a> HRecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.bytes().take(5).all(|b| b.is_ascii()) {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let data_source = DataSource::from_byte(bytes[1]);

--- a/src/records/h_record.rs
+++ b/src/records/h_record.rs
@@ -53,7 +53,8 @@ impl<'a> HRecord<'a> {
 
         let friendly_name;
         let data;
-        if let Some(colon_idx) = line.find(':') {
+        if let Some(colon_idx) = &line[5..].find(':') {
+            let colon_idx = *colon_idx + 5;
             friendly_name = Some(&line[5..colon_idx]);
             data = &line[colon_idx + 1..];
         } else {
@@ -115,6 +116,29 @@ mod tests {
     fn parse_with_missing_content() {
         assert!(HRecord::parse("H").is_err());
         assert!(HRecord::parse("HXXX").is_err());
+    }
+
+    #[test]
+    fn parse_with_early_colon() {
+        assert_eq!(
+            HRecord::parse("H:00 a ").unwrap(),
+            HRecord {
+                data_source: DataSource::Unrecognized(b':'),
+                mnemonic: "00 ",
+                friendly_name: None,
+                data: "a ",
+            }
+        );
+
+        assert_eq!(
+            HRecord::parse("HAaA :a").unwrap(),
+            HRecord {
+                data_source: DataSource::Unrecognized(b'A'),
+                mnemonic: "aA ",
+                friendly_name: Some(""),
+                data: "a",
+            }
+        );
     }
 
     #[test]

--- a/src/records/h_record.rs
+++ b/src/records/h_record.rs
@@ -45,6 +45,9 @@ impl<'a> HRecord<'a> {
         let bytes = line.as_bytes();
         assert_eq!(bytes[0], b'H');
 
+        if bytes.len() < 6 {
+            return Err(ParseError::SyntaxError);
+        }
         let data_source = DataSource::from_byte(bytes[1]);
         let mnemonic = &line[2..5];
 
@@ -106,6 +109,12 @@ mod tests {
         };
 
         assert_eq!(parsed_record, expected);
+    }
+
+    #[test]
+    fn parse_with_missing_content() {
+        assert!(HRecord::parse("H").is_err());
+        assert!(HRecord::parse("HXXX").is_err());
     }
 
     #[test]

--- a/src/records/h_record.rs
+++ b/src/records/h_record.rs
@@ -48,6 +48,10 @@ impl<'a> HRecord<'a> {
         if bytes.len() < 6 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(2) || !line.is_char_boundary(5) {
+            return Err(ParseError::SyntaxError);
+        }
+
         let data_source = DataSource::from_byte(bytes[1]);
         let mnemonic = &line[2..5];
 
@@ -142,6 +146,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(HRecord::parse("H\u{1107f}").is_err());
+    }
+
+    #[test]
     fn hrecord_format() {
         let expected_string = "HFGIDGLIDERID:D-KOOL";
         let record = HRecord {
@@ -152,5 +161,13 @@ mod tests {
         };
 
         assert_eq!(format!("{}", record), expected_string);
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "H\\PC*") {
+            HRecord::parse(&s);
+        }
     }
 }

--- a/src/records/h_record.rs
+++ b/src/records/h_record.rs
@@ -48,7 +48,7 @@ impl<'a> HRecord<'a> {
         if bytes.len() < 6 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(2) || !line.is_char_boundary(5) {
+        if !line.bytes().take(5).all(|b| b.is_ascii()) {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/k_record.rs
+++ b/src/records/k_record.rs
@@ -19,7 +19,7 @@ impl<'a> KRecord<'a> {
         if line.len() <= 7 {
             return Err(ParseError::SyntaxError);
         }
-        if !line.is_char_boundary(7) {
+        if !line.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/records/k_record.rs
+++ b/src/records/k_record.rs
@@ -20,7 +20,7 @@ impl<'a> KRecord<'a> {
             return Err(ParseError::SyntaxError);
         }
         if !line.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let time = line[1..7].parse()?;

--- a/src/records/k_record.rs
+++ b/src/records/k_record.rs
@@ -19,6 +19,9 @@ impl<'a> KRecord<'a> {
         if line.len() <= 7 {
             return Err(ParseError::SyntaxError);
         }
+        if !line.is_char_boundary(7) {
+            return Err(ParseError::SyntaxError);
+        }
 
         let time = line[1..7].parse()?;
         let extension_string = &line[7..];
@@ -62,6 +65,11 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_invalid_char_boundary() {
+        assert!(KRecord::parse("Kኲበ᧞").is_err());
+    }
+
+    #[test]
     fn krecord_format() {
         let expected_string = "K095214FooTheBar";
         let record = KRecord {
@@ -97,5 +105,13 @@ mod tests {
         assert_eq!(record.get_extension(&ext1).unwrap(), "Foo");
         assert_eq!(record.get_extension(&ext2).unwrap(), "The");
         assert_eq!(record.get_extension(&ext3).unwrap(), "Bar");
+    }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "K\\PC*") {
+            KRecord::parse(&s);
+        }
     }
 }

--- a/src/records/l_record.rs
+++ b/src/records/l_record.rs
@@ -48,4 +48,12 @@ mod tests {
 
         assert_eq!(format!("{}", record), expected_string);
     }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn parse_doesnt_crash(s in "L\\PC*") {
+            LRecord::parse(&s);
+        }
+    }
 }

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -83,6 +83,10 @@ impl<'a> Record<'a> {
     /// }
     /// ```
     pub fn parse_line(line: &'a str) -> Result<Self, ParseError> {
+        if line.is_empty() {
+            return Err(ParseError::SyntaxError);
+        }
+
         let rec = match line.as_bytes()[0] {
             b'A' => Record::A(ARecord::parse(line)?),
             b'B' => Record::B(BRecord::parse(line)?),
@@ -136,6 +140,11 @@ impl<'a> fmt::Display for Record<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_empty_string() {
+        assert!(Record::parse_line("").is_err());
+    }
 
     #[test]
     fn record_parse_line() {

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -161,4 +161,12 @@ mod tests {
 
         assert_eq!(format!("{}", rec), expected_str);
     }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn doesnt_crash(s in "\\PC*") {
+            Record::parse_line(&s);
+        }
+    }
 }

--- a/src/util/coord.rs
+++ b/src/util/coord.rs
@@ -82,6 +82,10 @@ impl FromStr for RawLatitude {
             "Raw latitude strings are 8 characters long"
         );
 
+        if !lat_string.is_char_boundary(2) || !lat_string.is_char_boundary(7) {
+            return Err(ParseError::SyntaxError);
+        }
+
         let degrees = lat_string[0..2].parse::<u8>()?;
         let minute_thousandths = lat_string[2..7].parse::<u16>()?;
         let sign = match &lat_string[7..8] {
@@ -152,6 +156,10 @@ impl FromStr for RawLongitude {
             "Raw longitude strings are 9 characters long"
         );
 
+        if !lon_string.is_char_boundary(3) || !lon_string.is_char_boundary(8) {
+            return Err(ParseError::SyntaxError);
+        }
+
         let degrees = lon_string[0..3].parse::<u8>()?;
         let minute_thousandths = lon_string[3..8].parse::<u16>()?;
         let sign = match &lon_string[8..9] {
@@ -206,6 +214,11 @@ impl FromStr for RawPosition {
 
     fn from_str(pos_string: &str) -> Result<Self, ParseError> {
         assert_eq!(pos_string.len(), 17);
+
+        if !pos_string.is_char_boundary(8) {
+            return Err(ParseError::SyntaxError);
+        }
+
         let lat = pos_string[0..8].parse()?;
         let lon = pos_string[8..17].parse()?;
 
@@ -238,6 +251,11 @@ mod test {
     }
 
     #[test]
+    fn raw_lat_parse_with_invalid_char_boundary() {
+        assert!("🌀aaaa".parse::<RawLatitude>().is_err());
+    }
+
+    #[test]
     fn raw_coord_parse_lon() {
         assert_eq!(
             RawLongitude::new(51, 52_265, Compass::East),
@@ -248,6 +266,11 @@ mod test {
             RawLongitude::new(51, 52_265, Compass::West),
             "05152265W".parse().unwrap()
         );
+    }
+
+    #[test]
+    fn raw_lon_parse_with_invalid_char_boundary() {
+        assert!("🌀aaaaa".parse::<RawLongitude>().is_err());
     }
 
     #[test]
@@ -283,6 +306,11 @@ mod test {
                 lon: RawLongitude::new(51, 52_265, Compass::West)
             }
         );
+    }
+
+    #[test]
+    fn parse_raw_position_with_invalid_char_boundary() {
+        assert!("🌀🌀🌀🌀a".parse::<RawPosition>().is_err());
     }
 
     #[test]

--- a/src/util/coord.rs
+++ b/src/util/coord.rs
@@ -82,7 +82,7 @@ impl FromStr for RawLatitude {
             "Raw latitude strings are 8 characters long"
         );
 
-        if !lat_string.is_char_boundary(2) || !lat_string.is_char_boundary(7) {
+        if !lat_string.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 
@@ -156,7 +156,7 @@ impl FromStr for RawLongitude {
             "Raw longitude strings are 9 characters long"
         );
 
-        if !lon_string.is_char_boundary(3) || !lon_string.is_char_boundary(8) {
+        if !lon_string.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 
@@ -215,7 +215,7 @@ impl FromStr for RawPosition {
     fn from_str(pos_string: &str) -> Result<Self, ParseError> {
         assert_eq!(pos_string.len(), 17);
 
-        if !pos_string.is_char_boundary(8) {
+        if !pos_string.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/util/coord.rs
+++ b/src/util/coord.rs
@@ -324,4 +324,26 @@ mod test {
             -51.87108333333333f64
         );
     }
+
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn raw_lat_parse_back_to_original(d in 0u8..90, m in 0u16..60_000) {
+            let lat = RawLatitude::new(d, m, Compass::North);
+            prop_assert_eq!(format!("{}", lat).parse::<RawLatitude>().unwrap(), lat);
+
+            let lat = RawLatitude::new(d, m, Compass::South);
+            prop_assert_eq!(format!("{}", lat).parse::<RawLatitude>().unwrap(), lat);
+        }
+
+        #[test]
+        #[allow(unused_must_use)]
+        fn raw_lon_parse_back_to_original(d in 0u8..180, m in 0u16..60_000) {
+            let lon = RawLongitude::new(d, m, Compass::East);
+            prop_assert_eq!(format!("{}", lon).parse::<RawLongitude>().unwrap(), lon);
+
+            let lon = RawLongitude::new(d, m, Compass::West);
+            prop_assert_eq!(format!("{}", lon).parse::<RawLongitude>().unwrap(), lon);
+        }
+    }
 }

--- a/src/util/coord.rs
+++ b/src/util/coord.rs
@@ -83,7 +83,7 @@ impl FromStr for RawLatitude {
         );
 
         if !lat_string.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let degrees = lat_string[0..2].parse::<u8>()?;
@@ -157,7 +157,7 @@ impl FromStr for RawLongitude {
         );
 
         if !lon_string.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let degrees = lon_string[0..3].parse::<u8>()?;
@@ -216,7 +216,7 @@ impl FromStr for RawPosition {
         assert_eq!(pos_string.len(), 17);
 
         if !pos_string.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let lat = pos_string[0..8].parse()?;

--- a/src/util/datetime.rs
+++ b/src/util/datetime.rs
@@ -17,6 +17,13 @@ impl Time {
     pub fn parse(time_string: &str) -> Result<Self, ParseError> {
         assert_eq!(time_string.len(), 6);
 
+        if !time_string.is_char_boundary(2)
+            || !time_string.is_char_boundary(4)
+            || !time_string.is_char_boundary(6)
+        {
+            return Err(ParseError::SyntaxError);
+        }
+
         let hours = time_string[0..2].parse::<u8>()?;
         let minutes = time_string[2..4].parse::<u8>()?;
         let seconds = time_string[4..6].parse::<u8>()?;
@@ -79,6 +86,13 @@ impl Date {
     pub fn parse(date_string: &str) -> Result<Self, ParseError> {
         assert_eq!(date_string.len(), 6);
 
+        if !date_string.is_char_boundary(2)
+            || !date_string.is_char_boundary(4)
+            || !date_string.is_char_boundary(6)
+        {
+            return Err(ParseError::SyntaxError);
+        }
+
         let day = date_string[0..2].parse::<u8>()?;
         let month = date_string[2..4].parse::<u8>()?;
         let year = date_string[4..6].parse::<u8>()?;
@@ -127,6 +141,11 @@ mod test {
     }
 
     #[test]
+    fn time_parse_with_invalid_char_boundary() {
+        assert!(Time::parse("🌀aa").is_err());
+    }
+
+    #[test]
     fn time_fmt() {
         assert_eq!(format!("{}", Time::from_hms(1, 23, 45)), "012345");
     }
@@ -135,6 +154,11 @@ mod test {
     fn date_parse() {
         assert_eq!("010118".parse::<Date>().unwrap(), Date::from_dmy(1, 1, 18));
         assert_eq!("120757".parse::<Date>().unwrap(), Date::from_dmy(12, 7, 57));
+    }
+
+    #[test]
+    fn date_parse_with_invalid_char_boundary() {
+        assert!(Date::parse("🌀aa").is_err());
     }
 
     #[test]

--- a/src/util/datetime.rs
+++ b/src/util/datetime.rs
@@ -18,7 +18,7 @@ impl Time {
         assert_eq!(time_string.len(), 6);
 
         if !time_string.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let hours = time_string[0..2].parse::<u8>()?;
@@ -84,7 +84,7 @@ impl Date {
         assert_eq!(date_string.len(), 6);
 
         if !date_string.is_ascii() {
-            return Err(ParseError::SyntaxError);
+            return Err(ParseError::NonASCIICharacters);
         }
 
         let day = date_string[0..2].parse::<u8>()?;

--- a/src/util/datetime.rs
+++ b/src/util/datetime.rs
@@ -17,10 +17,7 @@ impl Time {
     pub fn parse(time_string: &str) -> Result<Self, ParseError> {
         assert_eq!(time_string.len(), 6);
 
-        if !time_string.is_char_boundary(2)
-            || !time_string.is_char_boundary(4)
-            || !time_string.is_char_boundary(6)
-        {
+        if !time_string.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 
@@ -86,10 +83,7 @@ impl Date {
     pub fn parse(date_string: &str) -> Result<Self, ParseError> {
         assert_eq!(date_string.len(), 6);
 
-        if !date_string.is_char_boundary(2)
-            || !date_string.is_char_boundary(4)
-            || !date_string.is_char_boundary(6)
-        {
+        if !date_string.is_ascii() {
             return Err(ParseError::SyntaxError);
         }
 

--- a/src/util/datetime.rs
+++ b/src/util/datetime.rs
@@ -166,4 +166,19 @@ mod test {
         assert_eq!(format!("{}", Date::from_dmy(5, 10, 18)), "051018");
     }
 
+    proptest! {
+        #[test]
+        #[allow(unused_must_use)]
+        fn time_parse_back_to_original(h in 0u8..24, m in 0u8..60, s in 0u8..60) {
+            let time = Time::from_hms(h, m, s);
+            prop_assert_eq!(Time::parse(&format!("{}", time)).unwrap(), time);
+        }
+
+        #[test]
+        #[allow(unused_must_use)]
+        fn date_parse_back_to_original(d in 1u8..32, m in 1u8..13, y in 0u8..100) {
+            let date = Date::from_dmy(d, m, y);
+            prop_assert_eq!(Date::parse(&format!("{}", date)).unwrap(), date);
+        }
+    }
 }

--- a/src/util/parse_error.rs
+++ b/src/util/parse_error.rs
@@ -7,6 +7,7 @@ pub enum ParseError {
     IOError(io::Error),
     Utf8Error(std::str::Utf8Error),
     SyntaxError,
+    NonASCIICharacters,
     NumberOutOfRange,
     BadExtension,
     MissingExtension,


### PR DESCRIPTION
I'd say these `proptest` checks have already paid off... 😅 

Resolves #5