### PR TITLE
Add support for old A record spec

### DIFF
--- a/proptest-regressions/records/a_record.txt
+++ b/proptest-regressions/records/a_record.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 xs 3244273881 1542399201 2325479061 4046880040 # shrinks to s = "A0ꢀ￼"
+xs 1972609385 302227325 225717268 2390862986 # shrinks to s = "AaA 🃁"

--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -156,6 +156,18 @@ pub struct ARecord<'a> {
 }
 
 impl<'a> ARecord<'a> {
+    pub fn new(
+        manufacturer: Manufacturer<'a>,
+        unique_id: &'a str,
+        id_extension: Option<&'a str>,
+    ) -> ARecord<'a> {
+        ARecord {
+            manufacturer,
+            unique_id,
+            id_extension,
+        }
+    }
+
     /// Parse an IGC A Record string
     ///
     /// ```
@@ -183,11 +195,7 @@ impl<'a> ARecord<'a> {
             None
         };
 
-        Ok(ARecord {
-            manufacturer,
-            unique_id,
-            id_extension,
-        })
+        Ok(ARecord::new(manufacturer, unique_id, id_extension))
     }
 }
 
@@ -212,11 +220,7 @@ mod tests {
     fn arecord_parse() {
         assert_eq!(
             ARecord::parse("ACAMWatFoo").unwrap(),
-            ARecord {
-                manufacturer: Manufacturer::CambridgeAeroInstruments,
-                unique_id: "Wat",
-                id_extension: Some("Foo")
-            }
+            ARecord::new(Manufacturer::CambridgeAeroInstruments, "Wat", Some("Foo"))
         );
     }
 
@@ -230,11 +234,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                ARecord {
-                    manufacturer: Manufacturer::CambridgeAeroInstruments,
-                    unique_id: "Wat",
-                    id_extension: Some("Foo")
-                }
+                ARecord::new(Manufacturer::CambridgeAeroInstruments, "Wat", Some("Foo"))
             ),
             "ACAMWatFoo"
         );

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -155,11 +155,11 @@ mod tests {
         let rec = Record::parse_line("ACAMWatFoo").unwrap();
         assert_eq!(
             rec,
-            Record::A(ARecord {
-                manufacturer: Manufacturer::CambridgeAeroInstruments,
-                unique_id: "Wat",
-                id_extension: Some("Foo")
-            })
+            Record::A(ARecord::new(
+                Manufacturer::CambridgeAeroInstruments,
+                "Wat",
+                Some("Foo")
+            ))
         );
     }
 
@@ -171,11 +171,11 @@ mod tests {
     #[test]
     fn record_format() {
         let expected_str = "ACAMWatFoo";
-        let rec = Record::A(ARecord {
-            manufacturer: Manufacturer::CambridgeAeroInstruments,
-            unique_id: "Wat",
-            id_extension: Some("Foo"),
-        });
+        let rec = Record::A(ARecord::new(
+            Manufacturer::CambridgeAeroInstruments,
+            "Wat",
+            Some("Foo"),
+        ));
 
         assert_eq!(format!("{}", rec), expected_str);
     }


### PR DESCRIPTION
As commented in https://github.com/Joey9801/igc-rs/issues/2#issuecomment-451388871 there are a few loggers that use the old A record spec or a hybrid of both. This PR adds support for these kinds of loggers by assuming that their logger ID is always five *numeric* characters. So far I have not found any IGC files that contradict that assumption.

A theoretical case where this heuristic fails is `AABC000123`, where the logger assumes that `123` is meant as the extra text and `000` is the logger ID. To avoid this conflict the current IGC spec explicitly recommends to use `:123` instead, so that should not be an issue. The `FLIGHTS:1` case is also handled correctly by this assumption.

I have also moved the `Manufacturer` enum into a dedicated file in this PR, though at this point I'm not sure if we actually need it anymore. Since we support one- and three-character manufacturer IDs now, it is much easier to save the `&'a str` in the struct than to turn it into an enum which would have to support `Unknown` variants too. The other issue with the `Manufacturer` enum is that for serializing it back `TriadisEngineering` could mean `TRI` or `T`, but we can't be sure as that information would have been lost in the parsing step.