### PR TITLE
CI: Add "WebAssembly" job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,12 @@ jobs:
 
       script:
         - cargo clippy
+
+    - name: WebAssembly
+      rust: 1.31.0
+
+      install:
+        - rustup target add wasm32-unknown-unknown
+
+      script:
+        - cargo check --target wasm32-unknown-unknown


### PR DESCRIPTION
This new job will ensure that the crate stays compatible with WebAssembly so that it can be used in the browser.