### PR TITLE
Move `Manufacturer` enum to dedicated file

### DIFF
--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -1,151 +1,8 @@
 use std::fmt;
 
 use crate::util::DisplayOption;
+use crate::util::Manufacturer;
 use crate::util::ParseError;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum Manufacturer<'a> {
-    Aircotec,
-    CambridgeAeroInstruments,
-    ClearNavInstruments,
-    DataSwan,
-    EwAvionics,
-    Filser,
-    Flarm,
-    Flytech,
-    Garrecht,
-    ImiGlidingEquipment,
-    Logstream,
-    LxNavigation,
-    LxNav,
-    Naviter,
-    NewTechnologies,
-    NielsenKellerman,
-    Peschges,
-    PressFinishElectronics,
-    PrintTechnik,
-    Scheffel,
-    StreamlineDataInstruments,
-    TriadisEngineering,
-    Zander,
-    UnknownSingle(u8),
-    UnknownTriple(&'a str),
-}
-
-impl<'a> Manufacturer<'a> {
-    pub fn parse_single_char(character: u8) -> Self {
-        use self::Manufacturer::*;
-        match character {
-            b'I' => Aircotec,
-            b'C' => CambridgeAeroInstruments,
-            b'D' => DataSwan,
-            b'E' => EwAvionics,
-            b'F' => Filser,
-            b'G' => Flarm,
-            b'A' => Garrecht,
-            b'M' => ImiGlidingEquipment,
-            b'L' => LxNavigation,
-            b'V' => LxNav,
-            b'N' => NewTechnologies,
-            b'K' => NielsenKellerman,
-            b'P' => Peschges,
-            b'R' => PrintTechnik,
-            b'H' => Scheffel,
-            b'S' => StreamlineDataInstruments,
-            b'T' => TriadisEngineering,
-            b'Z' => Zander,
-            unknown => UnknownSingle(unknown),
-        }
-    }
-
-    pub fn parse_triple_char(triple: &'a str) -> Self {
-        use self::Manufacturer::*;
-        match triple {
-            "ACT" => Aircotec,
-            "CAM" => CambridgeAeroInstruments,
-            "CNI" => ClearNavInstruments,
-            "DSX" => DataSwan,
-            "EWA" => EwAvionics,
-            "FIL" => Filser,
-            "FLA" => Flarm,
-            "FLY" => Flytech,
-            "GCS" => Garrecht,
-            "IMI" => ImiGlidingEquipment,
-            "LGS" => Logstream,
-            "LXN" => LxNavigation,
-            "LXV" => LxNav,
-            "NAV" => Naviter,
-            "NTE" => NewTechnologies,
-            "NKL" => NielsenKellerman,
-            "PES" => Peschges,
-            "PFE" => PressFinishElectronics,
-            "PRT" => PrintTechnik,
-            "SCH" => Scheffel,
-            "SDI" => StreamlineDataInstruments,
-            "TRI" => TriadisEngineering,
-            "ZAN" => Zander,
-            _ => UnknownTriple(triple),
-        }
-    }
-
-    pub fn to_single_char(&self) -> Option<u8> {
-        use self::Manufacturer::*;
-        // It's sad that rustfmt currently nukes the alignment on these match arms
-        match self {
-            Aircotec => Some(b'I'),
-            CambridgeAeroInstruments => Some(b'C'),
-            DataSwan => Some(b'D'),
-            EwAvionics => Some(b'E'),
-            Filser => Some(b'F'),
-            Flarm => Some(b'G'),
-            Garrecht => Some(b'A'),
-            ImiGlidingEquipment => Some(b'M'),
-            LxNavigation => Some(b'L'),
-            LxNav => Some(b'V'),
-            NewTechnologies => Some(b'N'),
-            NielsenKellerman => Some(b'K'),
-            Peschges => Some(b'P'),
-            PrintTechnik => Some(b'R'),
-            Scheffel => Some(b'H'),
-            StreamlineDataInstruments => Some(b'S'),
-            TriadisEngineering => Some(b'T'),
-            Zander => Some(b'Z'),
-            UnknownSingle(s) => Some(*s),
-            _ => None,
-        }
-    }
-
-    pub fn to_triple_char(&self) -> Option<&'a str> {
-        use self::Manufacturer::*;
-        match self {
-            Aircotec => Some("ACT"),
-            CambridgeAeroInstruments => Some("CAM"),
-            ClearNavInstruments => Some("CNI"),
-            DataSwan => Some("DSX"),
-            EwAvionics => Some("EWA"),
-            Filser => Some("FIL"),
-            Flarm => Some("FLA"),
-            Flytech => Some("FLY"),
-            Garrecht => Some("GCS"),
-            ImiGlidingEquipment => Some("IMI"),
-            Logstream => Some("LGS"),
-            LxNavigation => Some("LXN"),
-            LxNav => Some("LXV"),
-            Naviter => Some("NAV"),
-            NewTechnologies => Some("NTE"),
-            NielsenKellerman => Some("NKL"),
-            Peschges => Some("PES"),
-            PressFinishElectronics => Some("PFE"),
-            PrintTechnik => Some("PRT"),
-            Scheffel => Some("SCH"),
-            StreamlineDataInstruments => Some("SDI"),
-            TriadisEngineering => Some("TRI"),
-            Zander => Some("ZAN"),
-            UnknownTriple(t) => Some(t),
-            _ => None,
-        }
-    }
-}
 
 /// Represents the FVU ID record
 #[derive(Debug, PartialEq, Eq)]
@@ -159,7 +16,8 @@ impl<'a> ARecord<'a> {
     /// Parse an IGC A Record string
     ///
     /// ```
-    /// # use igc::records::{ ARecord, Manufacturer };
+    /// # use igc::records::ARecord;
+    /// # use igc::util::Manufacturer;
     /// let record = ARecord::parse("ACAMWatFoo").unwrap();
     /// assert_eq!(record.manufacturer, Manufacturer::CambridgeAeroInstruments);
     /// assert_eq!(record.unique_id, "Wat");

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -144,6 +144,7 @@ impl<'a> fmt::Display for Record<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::Manufacturer;
 
     #[test]
     fn parse_empty_string() {

--- a/src/util/manufacturer.rs
+++ b/src/util/manufacturer.rs
@@ -1,0 +1,143 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Manufacturer<'a> {
+    Aircotec,
+    CambridgeAeroInstruments,
+    ClearNavInstruments,
+    DataSwan,
+    EwAvionics,
+    Filser,
+    Flarm,
+    Flytech,
+    Garrecht,
+    ImiGlidingEquipment,
+    Logstream,
+    LxNavigation,
+    LxNav,
+    Naviter,
+    NewTechnologies,
+    NielsenKellerman,
+    Peschges,
+    PressFinishElectronics,
+    PrintTechnik,
+    Scheffel,
+    StreamlineDataInstruments,
+    TriadisEngineering,
+    Zander,
+    UnknownSingle(u8),
+    UnknownTriple(&'a str),
+}
+
+impl<'a> Manufacturer<'a> {
+    pub fn parse_single_char(character: u8) -> Self {
+        use self::Manufacturer::*;
+        match character {
+            b'I' => Aircotec,
+            b'C' => CambridgeAeroInstruments,
+            b'D' => DataSwan,
+            b'E' => EwAvionics,
+            b'F' => Filser,
+            b'G' => Flarm,
+            b'A' => Garrecht,
+            b'M' => ImiGlidingEquipment,
+            b'L' => LxNavigation,
+            b'V' => LxNav,
+            b'N' => NewTechnologies,
+            b'K' => NielsenKellerman,
+            b'P' => Peschges,
+            b'R' => PrintTechnik,
+            b'H' => Scheffel,
+            b'S' => StreamlineDataInstruments,
+            b'T' => TriadisEngineering,
+            b'Z' => Zander,
+            unknown => UnknownSingle(unknown),
+        }
+    }
+
+    pub fn parse_triple_char(triple: &'a str) -> Self {
+        use self::Manufacturer::*;
+        match triple {
+            "ACT" => Aircotec,
+            "CAM" => CambridgeAeroInstruments,
+            "CNI" => ClearNavInstruments,
+            "DSX" => DataSwan,
+            "EWA" => EwAvionics,
+            "FIL" => Filser,
+            "FLA" => Flarm,
+            "FLY" => Flytech,
+            "GCS" => Garrecht,
+            "IMI" => ImiGlidingEquipment,
+            "LGS" => Logstream,
+            "LXN" => LxNavigation,
+            "LXV" => LxNav,
+            "NAV" => Naviter,
+            "NTE" => NewTechnologies,
+            "NKL" => NielsenKellerman,
+            "PES" => Peschges,
+            "PFE" => PressFinishElectronics,
+            "PRT" => PrintTechnik,
+            "SCH" => Scheffel,
+            "SDI" => StreamlineDataInstruments,
+            "TRI" => TriadisEngineering,
+            "ZAN" => Zander,
+            _ => UnknownTriple(triple),
+        }
+    }
+
+    pub fn to_single_char(&self) -> Option<u8> {
+        use self::Manufacturer::*;
+        // It's sad that rustfmt currently nukes the alignment on these match arms
+        match self {
+            Aircotec => Some(b'I'),
+            CambridgeAeroInstruments => Some(b'C'),
+            DataSwan => Some(b'D'),
+            EwAvionics => Some(b'E'),
+            Filser => Some(b'F'),
+            Flarm => Some(b'G'),
+            Garrecht => Some(b'A'),
+            ImiGlidingEquipment => Some(b'M'),
+            LxNavigation => Some(b'L'),
+            LxNav => Some(b'V'),
+            NewTechnologies => Some(b'N'),
+            NielsenKellerman => Some(b'K'),
+            Peschges => Some(b'P'),
+            PrintTechnik => Some(b'R'),
+            Scheffel => Some(b'H'),
+            StreamlineDataInstruments => Some(b'S'),
+            TriadisEngineering => Some(b'T'),
+            Zander => Some(b'Z'),
+            UnknownSingle(s) => Some(*s),
+            _ => None,
+        }
+    }
+
+    pub fn to_triple_char(&self) -> Option<&'a str> {
+        use self::Manufacturer::*;
+        match self {
+            Aircotec => Some("ACT"),
+            CambridgeAeroInstruments => Some("CAM"),
+            ClearNavInstruments => Some("CNI"),
+            DataSwan => Some("DSX"),
+            EwAvionics => Some("EWA"),
+            Filser => Some("FIL"),
+            Flarm => Some("FLA"),
+            Flytech => Some("FLY"),
+            Garrecht => Some("GCS"),
+            ImiGlidingEquipment => Some("IMI"),
+            Logstream => Some("LGS"),
+            LxNavigation => Some("LXN"),
+            LxNav => Some("LXV"),
+            Naviter => Some("NAV"),
+            NewTechnologies => Some("NTE"),
+            NielsenKellerman => Some("NKL"),
+            Peschges => Some("PES"),
+            PressFinishElectronics => Some("PFE"),
+            PrintTechnik => Some("PRT"),
+            Scheffel => Some("SCH"),
+            StreamlineDataInstruments => Some("SDI"),
+            TriadisEngineering => Some("TRI"),
+            Zander => Some("ZAN"),
+            UnknownTriple(t) => Some(t),
+            _ => None,
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,9 +3,11 @@
 mod coord;
 mod datetime;
 mod display_option;
+mod manufacturer;
 mod parse_error;
 
 pub use self::coord::{Compass, RawCoord, RawLatitude, RawLongitude, RawPosition};
 pub use self::datetime::{Date, Time};
 pub use self::display_option::DisplayOption;
+pub use self::manufacturer::Manufacturer;
 pub use self::parse_error::ParseError;


### PR DESCRIPTION
extracted from #20 

As you mentioned, these codes are also valuable for IGC filenames so IMHO it makes sense to keep them in a dedicated file.