### PR TITLE
ARecord: Extract `new()` constructor method

### DIFF
--- a/src/records/a_record.rs
+++ b/src/records/a_record.rs
@@ -156,6 +156,18 @@ pub struct ARecord<'a> {
 }
 
 impl<'a> ARecord<'a> {
+    pub fn new(
+        manufacturer: Manufacturer<'a>,
+        unique_id: &'a str,
+        id_extension: Option<&'a str>,
+    ) -> ARecord<'a> {
+        ARecord {
+            manufacturer,
+            unique_id,
+            id_extension,
+        }
+    }
+
     /// Parse an IGC A Record string
     ///
     /// ```
@@ -183,11 +195,7 @@ impl<'a> ARecord<'a> {
             None
         };
 
-        Ok(ARecord {
-            manufacturer,
-            unique_id,
-            id_extension,
-        })
+        Ok(ARecord::new(manufacturer, unique_id, id_extension))
     }
 }
 
@@ -212,11 +220,7 @@ mod tests {
     fn arecord_parse() {
         assert_eq!(
             ARecord::parse("ACAMWatFoo").unwrap(),
-            ARecord {
-                manufacturer: Manufacturer::CambridgeAeroInstruments,
-                unique_id: "Wat",
-                id_extension: Some("Foo")
-            }
+            ARecord::new(Manufacturer::CambridgeAeroInstruments, "Wat", Some("Foo"))
         );
     }
 
@@ -230,11 +234,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                ARecord {
-                    manufacturer: Manufacturer::CambridgeAeroInstruments,
-                    unique_id: "Wat",
-                    id_extension: Some("Foo")
-                }
+                ARecord::new(Manufacturer::CambridgeAeroInstruments, "Wat", Some("Foo"))
             ),
             "ACAMWatFoo"
         );

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -155,11 +155,11 @@ mod tests {
         let rec = Record::parse_line("ACAMWatFoo").unwrap();
         assert_eq!(
             rec,
-            Record::A(ARecord {
-                manufacturer: Manufacturer::CambridgeAeroInstruments,
-                unique_id: "Wat",
-                id_extension: Some("Foo")
-            })
+            Record::A(ARecord::new(
+                Manufacturer::CambridgeAeroInstruments,
+                "Wat",
+                Some("Foo")
+            ))
         );
     }
 
@@ -171,11 +171,11 @@ mod tests {
     #[test]
     fn record_format() {
         let expected_str = "ACAMWatFoo";
-        let rec = Record::A(ARecord {
-            manufacturer: Manufacturer::CambridgeAeroInstruments,
-            unique_id: "Wat",
-            id_extension: Some("Foo"),
-        });
+        let rec = Record::A(ARecord::new(
+            Manufacturer::CambridgeAeroInstruments,
+            "Wat",
+            Some("Foo"),
+        ));
 
         assert_eq!(format!("{}", rec), expected_str);
     }


### PR DESCRIPTION
extracted from #20 