### PR TITLE
Expose FixValid enum

### DIFF
--- a/src/records/b_record.rs
+++ b/src/records/b_record.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::records::extension::Extendable;
 use crate::util::{ParseError, RawPosition, Time};
 
-/// Possible values for the "fix valid" field of a B Record
+/// Possible values for the "fix valid" field of a B record
 #[derive(Debug, PartialEq, Eq)]
 pub enum FixValid {
     Valid,

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -33,7 +33,7 @@ mod k_record;
 mod l_record;
 
 pub use self::a_record::*;
-pub use self::b_record::BRecord;
+pub use self::b_record::{BRecord, FixValid};
 pub use self::c_record::{CRecordDeclaration, CRecordTurnpoint};
 pub use self::d_record::DRecord;
 pub use self::e_record::ERecord;


### PR DESCRIPTION
It's not visible if the module that contains it is not public.