### PR TITLE
ParseError: Use `thiserror` to implement `Error` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"], optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 approx = "0.5.0"

--- a/src/util/parse_error.rs
+++ b/src/util/parse_error.rs
@@ -1,26 +1,29 @@
 use std::io;
 use std::num;
 
+use thiserror::Error;
+
 /// Enumeration of different errors that can occur during parsing
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ParseError {
-    IOError(io::Error),
-    Utf8Error(std::str::Utf8Error),
+    #[error(transparent)]
+    IOError(#[from] io::Error),
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+    #[error("Syntax error found")]
     SyntaxError,
+    #[error("Non-ASCII characters found")]
     NonASCIICharacters,
+    #[error("Invalid number found")]
     NumberOutOfRange,
+    #[error("Invalid extension record found")]
     BadExtension,
+    #[error("Extension record missing")]
     MissingExtension,
 }
 
 impl From<num::ParseIntError> for ParseError {
     fn from(_: num::ParseIntError) -> Self {
         ParseError::SyntaxError
-    }
-}
-
-impl From<std::str::Utf8Error> for ParseError {
-    fn from(e: std::str::Utf8Error) -> Self {
-        ParseError::Utf8Error(e)
     }
 }


### PR DESCRIPTION
This PR implements the `Error` trait of the std library for our `ParseError` enum. Instead of doing so manually we use https://github.com/dtolnay/thiserror to derive it automatically, based on annotations.

Resolves #30