### PR TITLE
Bump MSRV (Minimum Supported Rust Version) to v1.38.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
 
 language: rust
 rust:
-  - 1.31.0
+  - 1.38.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 [docs.rs]: https://docs.rs/igc
 
 **igc-rs provides a minimal, fast parser for IGC flight recorder record lines in the Rust language.**
+
+## Minimum Supported Rust Version
+
+The "Minimum Supported Rust Version" for this project is: **1.38.0**


### PR DESCRIPTION
This should hopefully fix the broken CI jobs.

The v1.38.0 value was determined by https://crates.io/crates/cargo-msrv